### PR TITLE
Add macOS-style professional mode + mode toggle

### DIFF
--- a/assets/css/mobile-enhanced.css
+++ b/assets/css/mobile-enhanced.css
@@ -44,11 +44,17 @@
 
 /* ===== Mobile Grid Layout for Desktop Icons ===== */
 @media (max-width: 768px) {
+    /* Use the dynamic viewport unit (`dvh`) so the desktop sizes itself
+       against the *visible* viewport — i.e. excluding the iOS Safari URL
+       bar and Android browser chrome. Fall back to 100vh for older browsers.
+       The taskbar on mobile is 50px tall + safe-area-bottom, so subtract that. */
     #desktop {
+        height: calc(100vh - 50px - var(--safe-area-inset-bottom));
+        height: calc(100dvh - 50px - var(--safe-area-inset-bottom));
         padding-top: var(--safe-area-inset-top);
         padding-left: var(--mobile-padding);
         padding-right: var(--mobile-padding);
-        padding-bottom: calc(60px + var(--safe-area-inset-bottom));
+        padding-bottom: 12px;
     }
     
     /* Desktop icons container with grid */
@@ -511,14 +517,9 @@
     }
 }
 
-/* ===== Fix for iOS Safari URL bar ===== */
+/* ===== Fix for iOS Safari URL bar (dvh fallback for older iOS) ===== */
 @supports (-webkit-touch-callout: none) {
     @media (max-width: 768px) {
-        #desktop {
-            height: 100vh;
-            height: -webkit-fill-available;
-        }
-        
         body {
             height: 100vh;
             height: -webkit-fill-available;

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -100,11 +100,11 @@
     font-weight: 500;
 }
 
-/* Floating Action Button */
+/* Floating Action Button — positioned above the mobile taskbar (50px) + safe-area */
 .mobile-fab {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    bottom: calc(50px + env(safe-area-inset-bottom, 0px) + 12px);
+    right: calc(16px + env(safe-area-inset-right, 0px));
     width: var(--mobile-fab-size);
     height: var(--mobile-fab-size);
     background: linear-gradient(45deg, #0ff, #00a8cc);
@@ -443,8 +443,8 @@
     }
 
     .mobile-fab {
-        bottom: 15px;
-        right: 15px;
+        bottom: calc(50px + env(safe-area-inset-bottom, 0px) + 8px);
+        right: calc(12px + env(safe-area-inset-right, 0px));
     }
 }
 

--- a/assets/css/professional.css
+++ b/assets/css/professional.css
@@ -1,0 +1,1700 @@
+/* ============================================================
+   PROFESSIONAL MODE — macOS (Sonoma / Sequoia)
+   Authentic Apple tokens. Cool gray chrome over Helios-style
+   gradient wallpaper. Inter Tight + system-ui fallback so Apple
+   users get real SF Pro. PuruVJ + Renovamen as references.
+   ============================================================ */
+
+/* ============================================================
+   MODE VISIBILITY
+   ============================================================ */
+html[data-mode="professional"] #desktop,
+html[data-mode="professional"] #start-menu,
+html[data-mode="professional"] #taskbar,
+html[data-mode="professional"] #matrix-rain,
+html[data-mode="professional"] #mobile-nav,
+html[data-mode="professional"] #mobile-nav-overlay,
+html[data-mode="professional"] #mobile-fab { display: none !important; }
+
+html[data-mode="creative"] #professional-mode { display: none !important; }
+#professional-mode { display: none; }
+html[data-mode="professional"] #professional-mode { display: block; }
+
+html[data-mode="professional"],
+html[data-mode="professional"] body {
+    overflow: hidden;
+    height: 100%;
+    background: #1A1A1F;
+    cursor: auto;
+}
+html[data-mode="professional"] body {
+    user-select: text;
+    -webkit-user-select: text;
+}
+
+/* ============================================================
+   DESIGN TOKENS — authentic Apple
+   ============================================================ */
+#professional-mode {
+    /* Traffic lights — PuruVJ-confirmed Big Sur+ values */
+    --tl-close-fill:    #FF5F57;
+    --tl-close-border:  #E04339;
+    --tl-min-fill:      #FEBC2E;
+    --tl-min-border:    #DEA31E;
+    --tl-max-fill:      #28C840;
+    --tl-max-border:    #18AB29;
+    --tl-inactive-fill: #DDDCDC;
+    --tl-inactive-border: rgba(0, 0, 0, 0.08);
+    --tl-glyph:         rgba(0, 0, 0, 0.55);
+
+    /* System colors — light mode */
+    --system-bg:        #FFFFFF;
+    --system-bg-2:      #F2F2F7;
+    --system-bg-3:      #E5E5EA;
+    --label:            rgba(0, 0, 0, 0.85);
+    --label-2:          rgba(60, 60, 67, 0.60);
+    --label-3:          rgba(60, 60, 67, 0.30);
+    --label-4:          rgba(60, 60, 67, 0.18);
+    --separator:        rgba(60, 60, 67, 0.29);
+    --separator-opaque: #C6C6C8;
+
+    --system-blue:      #007AFF;
+    --system-blue-soft: rgba(0, 122, 255, 0.14);
+    --system-red:       #FF3B30;
+    --system-green:     #34C759;
+    --system-orange:    #FF9500;
+    --system-yellow:    #FFCC00;
+    --system-purple:    #AF52DE;
+    --system-pink:      #FF2D55;
+    --system-indigo:    #5856D6;
+
+    --system-gray:      #8E8E93;
+    --system-gray-2:    #AEAEB2;
+    --system-gray-3:    #C7C7CC;
+    --system-gray-4:    #D1D1D6;
+    --system-gray-5:    #E5E5EA;
+    --system-gray-6:    #F2F2F7;
+
+    /* Window chrome.
+       Shadow stack mirrors real Sequoia: tight contact shadow (10px),
+       a medium drop (30px) for body separation, and a tall blur (60px)
+       for ambient occlusion. The 0.5px hairline keeps the edge crisp
+       on retina without looking drawn-on. */
+    --win-radius:       10px;
+    --win-titlebar-h:   28px;
+    --win-border:       0.5px solid rgba(0, 0, 0, 0.18);
+    --win-shadow:
+        0 0 0 0.5px rgba(0, 0, 0, 0.22),
+        0 6px 14px rgba(0, 0, 0, 0.18),
+        0 24px 48px rgba(0, 0, 0, 0.24),
+        0 48px 96px rgba(0, 0, 0, 0.20);
+    --win-shadow-inactive:
+        0 0 0 0.5px rgba(0, 0, 0, 0.14),
+        0 4px 10px rgba(0, 0, 0, 0.10),
+        0 14px 30px rgba(0, 0, 0, 0.10),
+        0 28px 56px rgba(0, 0, 0, 0.08);
+
+    /* Vibrancy materials (all paired with saturate amplification) */
+    --m-titlebar-bg:    rgba(246, 246, 246, 0.72);
+    --m-window-bg:      rgba(246, 246, 246, 0.85);
+    --m-sidebar-bg:     rgba(246, 246, 246, 0.6);
+    --m-popover-bg:     rgba(255, 255, 255, 0.78);
+    --m-dock-bg:        rgba(255, 255, 255, 0.40);
+
+    /* Dock. Apple-spec icon container is ~54px with a squircle radius near
+       22-24% — 13px reads more "macOS Sequoia" than the 12px Big Sur look. */
+    --dock-radius:      22px;
+    --dock-icon:        54px;
+    --dock-icon-radius: 13px;
+    --dock-indicator:   rgba(0, 0, 0, 0.55);
+
+    /* Motion */
+    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+    --ease-soft:   cubic-bezier(0.22, 1, 0.36, 1);
+
+    /* Type stack — Apple users get real SF Pro via -apple-system */
+    --font-ui:
+        'Inter Tight',
+        -apple-system,
+        BlinkMacSystemFont,
+        'SF Pro Text',
+        'Segoe UI',
+        system-ui,
+        sans-serif;
+    --font-display: 'Fraunces', 'Times New Roman', 'Georgia', serif;
+    --font-mono: 'JetBrains Mono', 'SF Mono', 'IBM Plex Mono', 'Courier New', monospace;
+
+    /* Sizing */
+    --menubar-h: 28px;
+    --dock-h:    100px;
+
+    color: var(--label);
+    font-family: var(--font-ui);
+    font-size: 13px;
+    line-height: 1.45;
+    font-feature-settings: 'cv11', 'ss01', 'ss03';
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    height: 100vh; height: 100dvh;
+    width: 100%;
+    position: fixed; inset: 0;
+    overflow: hidden;
+    cursor: auto;
+    letter-spacing: -0.005em;
+}
+
+#professional-mode *,
+#professional-mode *::before,
+#professional-mode *::after {
+    box-sizing: border-box;
+    user-select: text; -webkit-user-select: text;
+}
+
+#professional-mode button {
+    font: inherit;
+    color: inherit;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    padding: 0;
+    -webkit-user-select: none; user-select: none;
+}
+
+/* ============================================================
+   WALLPAPER — Big Sur "Graphite" dusk
+   Cool blue / indigo / slate gradient. Desaturated, dim enough
+   that the macOS chrome reads cleanly against it. Vibrancy in
+   the menubar/dock/windows picks up just enough color to feel
+   alive without competing for attention.
+   ============================================================ */
+.pro-wallpaper {
+    position: absolute; inset: 0;
+    z-index: 0;
+    overflow: hidden;
+    background: #1A1F2E;
+}
+
+.pro-wallpaper__mesh {
+    position: absolute; inset: -8%;
+    /* Base: deep navy → twilight slate */
+    background-color: #1E2538;
+    background-image:
+        /* Cool blue glow upper-left (sky) */
+        radial-gradient(at 22% 18%, #3C5680 0px, transparent 55%),
+        /* Indigo wash upper-right */
+        radial-gradient(at 80% 22%, #4A4F8C 0px, transparent 55%),
+        /* Warmer ember lower-right — single subtle accent, NOT a riot */
+        radial-gradient(at 88% 78%, #6B4D78 0px, transparent 50%),
+        /* Cool teal lower-left for chromatic balance */
+        radial-gradient(at 18% 82%, #2D5C6E 0px, transparent 50%),
+        /* Soft graphite center holds the composition */
+        radial-gradient(at 52% 52%, #283149 0px, transparent 70%);
+    filter: blur(10px) saturate(85%) brightness(0.92);
+    animation: pro-mesh-drift 48s ease-in-out infinite alternate;
+}
+
+@keyframes pro-mesh-drift {
+    0%   { transform: translate(0, 0) scale(1.02); }
+    50%  { transform: translate(1.4%, 0.8%) scale(1.05); }
+    100% { transform: translate(-1%, -0.6%) scale(1.03); }
+}
+
+.pro-wallpaper__grain {
+    position: absolute; inset: 0;
+    pointer-events: none;
+    /* Lower opacity — the calmer wallpaper doesn't need a heavy grain to feel premium */
+    opacity: 0.14;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 220 220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.5 0 0 0 0 0.5 0 0 0 0 0.5 0 0 0 0.55 0'/></filter><rect width='220' height='220' filter='url(%23n)'/></svg>");
+}
+
+/* Subtle top-down darkening so the menubar reads against the wallpaper */
+.pro-wallpaper::after {
+    content: '';
+    position: absolute; inset: 0;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.18) 0%, transparent 14%, transparent 86%, rgba(0, 0, 0, 0.22) 100%);
+    pointer-events: none;
+}
+
+/* ============================================================
+   MENU BAR
+   ============================================================ */
+.pro-menubar {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: var(--menubar-h);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 14px;
+    z-index: 50;
+    color: rgba(255, 255, 255, 0.95);
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.2px;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
+
+    /* Vibrancy: blur over wallpaper with a real Sequoia-grade tint.
+       Over a dark wallpaper the bar needs ~22% black to read crisply;
+       saturate amplification picks up wallpaper color without going opaque.
+       The bottom hairline separates the bar from desktop content. */
+    background: rgba(0, 0, 0, 0.22);
+    backdrop-filter: blur(28px) saturate(190%);
+    -webkit-backdrop-filter: blur(28px) saturate(190%);
+    box-shadow:
+        inset 0 -0.5px 0 rgba(255, 255, 255, 0.06),
+        inset 0  0.5px 0 rgba(255, 255, 255, 0.14),
+        0    0.5px 0 rgba(0, 0, 0, 0.30);
+
+    animation: pro-menubar-in 0.7s var(--ease-soft) both;
+}
+
+@keyframes pro-menubar-in {
+    from { transform: translateY(-100%); opacity: 0; }
+    to   { transform: translateY(0); opacity: 1; }
+}
+
+.pro-menubar__left,
+.pro-menubar__right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+.pro-menubar__right { gap: 12px; }
+
+.pro-menubar__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+    font-size: 13.5px;
+    padding: 3px 6px;
+    margin-left: -6px;
+    border-radius: 4px;
+    transition: background 0.2s ease;
+    letter-spacing: -0.01em;
+    color: #fff;
+}
+.pro-menubar__brand:hover { background: rgba(255, 255, 255, 0.18); }
+
+/* Apple-logo replacement: a glossy chip */
+.pro-brand-mark {
+    width: 12px; height: 12px;
+    background: #fff;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M10.7 1.4c0 .9-.3 1.7-1 2.4-.7.7-1.5 1.1-2.4 1-.1-.8.3-1.7 1-2.4.6-.7 1.6-1 2.4-1zm2.7 9.3c0-2 1.7-3 1.8-3-.9-1.4-2.4-1.6-3-1.6-1.2-.1-2.5.7-3.1.7-.7 0-1.7-.7-2.8-.7-1.4 0-2.7.8-3.5 2.1-1.5 2.6-.4 6.4 1.1 8.5.7 1 1.5 2.2 2.6 2.2 1 0 1.5-.7 2.7-.7 1.3 0 1.6.7 2.7.7 1.1 0 1.9-1 2.6-2 .8-1.2 1.2-2.4 1.2-2.4-.1-.1-2.3-.9-2.3-3.8z'/></svg>") center / contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M10.7 1.4c0 .9-.3 1.7-1 2.4-.7.7-1.5 1.1-2.4 1-.1-.8.3-1.7 1-2.4.6-.7 1.6-1 2.4-1zm2.7 9.3c0-2 1.7-3 1.8-3-.9-1.4-2.4-1.6-3-1.6-1.2-.1-2.5.7-3.1.7-.7 0-1.7-.7-2.8-.7-1.4 0-2.7.8-3.5 2.1-1.5 2.6-.4 6.4 1.1 8.5.7 1 1.5 2.2 2.6 2.2 1 0 1.5-.7 2.7-.7 1.3 0 1.6.7 2.7.7 1.1 0 1.9-1 2.6-2 .8-1.2 1.2-2.4 1.2-2.4-.1-.1-2.3-.9-2.3-3.8z'/></svg>") center / contain no-repeat;
+}
+
+.pro-menubar__app {
+    font-weight: 600;
+    font-size: 13px;
+    color: #fff;
+}
+
+.pro-menubar__nav {
+    display: flex;
+    gap: 0;
+}
+.pro-menubar__nav button {
+    padding: 3px 9px;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.92);
+    transition: background 0.2s ease;
+}
+.pro-menubar__nav button:hover { background: rgba(255, 255, 255, 0.18); }
+
+/* Ticker chip */
+.pro-menubar__ticker {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.18);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-feature-settings: 'tnum';
+    color: #fff;
+}
+.pro-ticker__label { color: rgba(255, 255, 255, 0.75); font-weight: 500; letter-spacing: 0.04em; }
+.pro-ticker__value { font-weight: 600; }
+.pro-ticker__value.pro-up   { color: #6FE889; }
+.pro-ticker__value.pro-down { color: #FF8B81; }
+
+.pro-menubar__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.85);
+    letter-spacing: 0.04em;
+}
+.pro-pulse-dot {
+    width: 7px; height: 7px;
+    background: var(--system-green);
+    border-radius: 50%;
+    box-shadow: 0 0 0 3px rgba(52, 199, 89, 0.28);
+    animation: pro-pulse 2.4s ease-in-out infinite;
+}
+@keyframes pro-pulse {
+    0%, 100% { box-shadow: 0 0 0 3px rgba(52, 199, 89, 0.32); }
+    50%      { box-shadow: 0 0 0 6px rgba(52, 199, 89, 0.05); }
+}
+
+.pro-menubar__clock {
+    font-family: var(--font-ui);
+    font-size: 13px;
+    font-weight: 500;
+    color: #fff;
+    font-feature-settings: 'tnum';
+    letter-spacing: 0;
+}
+
+/* === Mode toggle in menubar (Apple-blue pill) === */
+.pro-mode-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 11px 4px 9px;
+    background: rgba(255, 255, 255, 0.22);
+    border: 0.5px solid rgba(255, 255, 255, 0.4);
+    border-radius: 99px;
+    font-family: var(--font-ui);
+    font-size: 11.5px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.25s ease, color 0.25s ease, transform 0.3s var(--ease-spring), border-color 0.25s ease;
+    line-height: 1;
+    overflow: hidden;
+}
+
+.pro-mode-toggle:hover {
+    background: var(--system-blue);
+    border-color: var(--system-blue);
+    transform: translateY(-1px);
+}
+
+.pro-mode-toggle__dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--system-blue);
+    box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.32);
+    transition: background 0.25s ease, box-shadow 0.25s ease;
+    flex-shrink: 0;
+}
+.pro-mode-toggle:hover .pro-mode-toggle__dot {
+    background: #fff;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.32);
+}
+
+/* Attention sweep (sells visibility) */
+.pro-mode-toggle--attention::before {
+    content: '';
+    position: absolute;
+    top: 0; bottom: 0;
+    left: -60%;
+    width: 50%;
+    background: linear-gradient(100deg, transparent 0%, rgba(255, 255, 255, 0.6) 50%, transparent 100%);
+    transform: skewX(-18deg);
+    animation: pro-shimmer 5.2s ease-in-out infinite;
+    pointer-events: none;
+    z-index: 0;
+}
+.pro-mode-toggle--attention > * { position: relative; z-index: 1; }
+
+@keyframes pro-shimmer {
+    0%        { left: -60%; }
+    35%, 100% { left: 130%; }
+}
+
+.pro-mode-toggle--attention {
+    animation: pro-toggle-halo 3.6s ease-in-out infinite;
+}
+@keyframes pro-toggle-halo {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(0, 122, 255, 0.45); }
+    50%      { box-shadow: 0 0 0 8px rgba(0, 122, 255, 0); }
+}
+.pro-mode-toggle--attention:hover { animation-play-state: paused; }
+
+/* ============================================================
+   DESKTOP — spotlight hero + glass widgets
+   ============================================================ */
+.pro-desktop {
+    position: absolute;
+    inset: var(--menubar-h) 0 var(--dock-h) 0;
+    z-index: 2;
+    padding: clamp(20px, 4vw, 56px);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 380px);
+    grid-template-rows: minmax(0, 1fr) auto;
+    gap: clamp(24px, 4vw, 56px);
+    align-content: center;
+    overflow: hidden;
+}
+
+.pro-spotlight {
+    align-self: end;
+    max-width: 720px;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+    animation: pro-rise 1s var(--ease-soft) 0.2s both;
+}
+
+.pro-spotlight__eyebrow {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 0 0 22px;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+.pro-spotlight__eyebrow::before {
+    content: '';
+    width: 28px; height: 1.5px;
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 1px;
+}
+
+.pro-spotlight__name {
+    font-family: var(--font-display);
+    font-weight: 380;
+    /* Slightly smaller cap than before — the hero should feel elegant
+       and assertive, not shout over the macOS chrome. The 88px ceiling
+       holds the composition together at large viewports. */
+    font-size: clamp(48px, 6.6vw, 88px);
+    line-height: 0.96;
+    letter-spacing: -0.034em;
+    margin: 0 0 20px;
+    font-variation-settings: 'opsz' 144;
+    color: #fff;
+    /* Soft glow + subtle shadow so the white type reads cleanly over the
+       graphite wallpaper without the heavy text-shadow look of older OSes. */
+    text-shadow:
+        0 1px 1px rgba(0, 0, 0, 0.20),
+        0 2px 18px rgba(0, 0, 0, 0.18);
+}
+.pro-spotlight__name em {
+    font-style: italic;
+    font-weight: 350;
+    color: rgba(255, 255, 255, 0.88);
+}
+.pro-spotlight__name span { color: rgba(255, 255, 255, 0.88); }
+
+.pro-spotlight__role {
+    font-family: var(--font-ui);
+    font-size: clamp(15px, 1.3vw, 17px);
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.92);
+    margin: 0;
+    max-width: 54ch;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+}
+
+.pro-spotlight__hint {
+    margin-top: 28px;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.78);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+.pro-spotlight__hint::before {
+    content: '';
+    width: 18px; height: 1px;
+    background: rgba(255, 255, 255, 0.6);
+}
+.pro-spotlight__hint .pro-arr-down {
+    display: inline-block;
+    animation: pro-bob 1.6s ease-in-out infinite;
+}
+@keyframes pro-bob {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(3px); }
+}
+
+/* Widget stack */
+.pro-widgets {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    align-self: end;
+    animation: pro-rise 1s var(--ease-soft) 0.45s both;
+}
+
+/* Double-inset hairline + raised top-edge highlight — matches real Sequoia
+   desktop widgets, which have a barely-visible top gloss that disappears
+   into the body. Shadow stack: contact + body + ambient. */
+.pro-widget {
+    position: relative;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.10) 0%, rgba(255, 255, 255, 0) 22%),
+        var(--m-window-bg);
+    backdrop-filter: blur(30px) saturate(180%);
+    -webkit-backdrop-filter: blur(30px) saturate(180%);
+    border-radius: 14px;
+    padding: 16px 18px;
+    box-shadow:
+        inset 0 0.5px 0 rgba(255, 255, 255, 0.85),
+        inset 0 0 0 0.5px rgba(255, 255, 255, 0.55),
+        inset 0 0 0 1px rgba(0, 0, 0, 0.05),
+        0 1px 2px rgba(0, 0, 0, 0.10),
+        0 12px 28px rgba(0, 0, 0, 0.22),
+        0 24px 48px rgba(0, 0, 0, 0.14);
+    color: var(--label);
+    transition: transform 0.4s var(--ease-spring), box-shadow 0.4s var(--ease-soft);
+}
+.pro-widget:hover {
+    transform: translateY(-2px);
+    box-shadow:
+        inset 0 0.5px 0 rgba(255, 255, 255, 0.9),
+        inset 0 0 0 0.5px rgba(255, 255, 255, 0.65),
+        inset 0 0 0 1px rgba(0, 0, 0, 0.05),
+        0 2px 4px rgba(0, 0, 0, 0.10),
+        0 18px 36px rgba(0, 0, 0, 0.26),
+        0 32px 60px rgba(0, 0, 0, 0.16);
+}
+
+.pro-widget__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 10px;
+}
+.pro-widget__title {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--label-2);
+    margin: 0;
+}
+.pro-widget__caption {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--system-blue);
+    font-weight: 500;
+}
+
+/* Ledger widget */
+.pro-widget--ledger dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+}
+.pro-widget--ledger .pro-row {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    padding: 6px 0;
+    border-top: 0.5px solid var(--separator);
+    align-items: baseline;
+}
+.pro-widget--ledger .pro-row:last-child { border-bottom: 0.5px solid var(--separator); }
+.pro-widget--ledger dt {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--label-2);
+}
+.pro-widget--ledger dd {
+    font-family: var(--font-ui);
+    font-size: 12.5px;
+    color: var(--label);
+    margin: 0;
+    font-feature-settings: 'tnum';
+    font-weight: 500;
+}
+
+/* Markets widget */
+.pro-widget--markets { position: relative; }
+.pro-markets {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    margin-top: 2px;
+}
+.pro-market {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.pro-market__sym {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--label-2);
+}
+.pro-market__val {
+    font-family: var(--font-mono);
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--label);
+    font-feature-settings: 'tnum';
+    letter-spacing: -0.02em;
+}
+.pro-market__delta {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    font-feature-settings: 'tnum';
+}
+.pro-market__delta.pro-up   { color: var(--system-green); }
+.pro-market__delta.pro-down { color: var(--system-red); }
+
+.pro-spark {
+    width: 100%; height: 32px;
+    margin-top: 10px;
+    display: block;
+}
+.pro-spark__line {
+    fill: none;
+    stroke: var(--system-blue);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 600;
+    stroke-dashoffset: 600;
+    animation: pro-draw 2.6s var(--ease-soft) 0.7s forwards;
+}
+.pro-spark__fill {
+    fill: var(--system-blue-soft);
+    opacity: 0;
+    animation: pro-fill-in 1s ease 2.5s forwards;
+}
+@keyframes pro-draw    { to { stroke-dashoffset: 0; } }
+@keyframes pro-fill-in { to { opacity: 1; } }
+
+/* Now playing widget */
+.pro-widget--now {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+}
+.pro-now__art {
+    width: 42px; height: 42px;
+    border-radius: 9px;
+    background:
+        radial-gradient(circle at 30% 30%, #B9D2FF 0%, transparent 60%),
+        linear-gradient(135deg, var(--system-blue) 0%, var(--system-indigo) 100%);
+    box-shadow:
+        inset 0 0 0 0.5px rgba(255, 255, 255, 0.4),
+        0 3px 8px -2px rgba(0, 122, 255, 0.5);
+    flex-shrink: 0;
+    position: relative;
+    overflow: hidden;
+}
+.pro-now__art::after {
+    content: '';
+    position: absolute;
+    inset: 8px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.16);
+    border: 0.5px solid rgba(255, 255, 255, 0.32);
+}
+.pro-now__art::before {
+    content: '';
+    position: absolute;
+    inset: 18px;
+    border-radius: 50%;
+    background: #1A1A1F;
+    z-index: 1;
+}
+.pro-now__body { min-width: 0; flex: 1; }
+.pro-now__label {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--label-2);
+    margin: 0 0 1px;
+    text-transform: uppercase;
+}
+.pro-now__title {
+    font-family: var(--font-ui);
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--label);
+    margin: 0;
+    letter-spacing: -0.01em;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.pro-now__bars {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 14px;
+    flex-shrink: 0;
+}
+.pro-now__bars span {
+    width: 2px;
+    background: var(--system-blue);
+    border-radius: 1px;
+    animation: pro-eq 1.1s ease-in-out infinite;
+}
+.pro-now__bars span:nth-child(1) { height: 40%; }
+.pro-now__bars span:nth-child(2) { height: 70%; animation-delay: 0.15s; }
+.pro-now__bars span:nth-child(3) { height: 55%; animation-delay: 0.3s; }
+.pro-now__bars span:nth-child(4) { height: 90%; animation-delay: 0.45s; }
+.pro-now__bars span:nth-child(5) { height: 35%; animation-delay: 0.6s; }
+@keyframes pro-eq {
+    0%, 100% { transform: scaleY(0.4); }
+    50%      { transform: scaleY(1); }
+}
+
+@keyframes pro-rise {
+    from { opacity: 0; transform: translateY(20px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ============================================================
+   WINDOWS — authentic macOS chrome
+   ============================================================ */
+.pro-window {
+    position: fixed;
+    top: 50%; left: 50%;
+    width: clamp(360px, 60vw, 720px);
+    max-height: calc(100vh - var(--menubar-h) - var(--dock-h) - 32px);
+
+    background: var(--m-window-bg);
+    backdrop-filter: blur(30px) saturate(180%);
+    -webkit-backdrop-filter: blur(30px) saturate(180%);
+
+    border-radius: var(--win-radius);
+    /* Double-inset hairline (PuruVJ): bright outer reads as glass edge,
+       1px dark inner gives the body a faint inner border. */
+    box-shadow:
+        inset 0 0.5px 0 rgba(255, 255, 255, 0.85),
+        inset 0 0 0 0.5px rgba(255, 255, 255, 0.65),
+        inset 0 0 0 1px rgba(0, 0, 0, 0.04),
+        var(--win-shadow);
+
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    opacity: 0;
+    visibility: hidden;
+    /* Slight scale-from-90% + 24px lift gives the macOS "spring open" feel
+       when paired with the spring easing curve. */
+    transform: translate(-50%, calc(-50% + 28px)) scale(0.90);
+    transition:
+        transform 0.55s var(--ease-spring),
+        opacity 0.32s ease,
+        visibility 0.32s linear,
+        box-shadow 0.4s var(--ease-soft),
+        filter 0.4s var(--ease-soft);
+    will-change: transform, opacity;
+}
+
+.pro-window.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, -50%) scale(1);
+}
+
+.pro-window.is-front { z-index: 30; }
+
+/* Unfocused windows: shallower shadow + faint desaturate so the focused
+   window visibly "comes forward" in the stack. */
+.pro-window:not(.is-front).is-open {
+    box-shadow:
+        inset 0 0 0 0.5px rgba(255, 255, 255, 0.55),
+        inset 0 0 0 1px rgba(0, 0, 0, 0.04),
+        var(--win-shadow-inactive);
+    filter: saturate(0.85);
+}
+
+.pro-window.is-max {
+    width: calc(100vw - 32px) !important;
+    max-height: calc(100vh - var(--menubar-h) - var(--dock-h) - 16px) !important;
+}
+
+/* Title bar — 28px Apple spec, vibrancy material.
+   Real Sequoia title bars have a faint top→bottom lightening that makes
+   the bar read as a "raised lip" — we layer a 1px gradient over the
+   vibrancy material to match that subtle 3D feel. */
+.pro-window__chrome {
+    height: var(--win-titlebar-h);
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.10) 0%, rgba(255, 255, 255, 0) 60%),
+        var(--m-titlebar-bg);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border-bottom: 0.5px solid var(--separator);
+    box-shadow: inset 0 0.5px 0 rgba(255, 255, 255, 0.55);
+    cursor: grab;
+    flex-shrink: 0;
+    -webkit-user-select: none; user-select: none;
+    position: relative;
+}
+.pro-window__chrome:active { cursor: grabbing; }
+
+/* Inactive window: chrome desaturates, raised highlight fades, title goes muted */
+.pro-window:not(.is-front) .pro-window__chrome {
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0) 60%),
+        rgba(244, 244, 246, 0.78);
+    box-shadow: inset 0 0.5px 0 rgba(255, 255, 255, 0.35);
+}
+.pro-window:not(.is-front) .pro-window__title { color: var(--label-2); }
+
+/* ============================================================
+   TRAFFIC LIGHTS — authentic Big Sur+ values
+   12px diameter, 8px gap, hover-on-cluster shows all glyphs
+   ============================================================ */
+.pro-window__lights {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    position: relative;
+    z-index: 2;
+}
+
+.pro-light {
+    width: 12px; height: 12px;
+    border-radius: 50%;
+    border: 0.5px solid;
+    cursor: pointer;
+    position: relative;
+    transition: filter 0.15s ease;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    flex-shrink: 0;
+    /* Subtle inner depth — darkens the bottom edge so the dot reads as a sphere,
+       not a flat disc. Pairs with the specular highlight (::after) below. */
+    box-shadow:
+        inset 0 -0.5px 0.5px rgba(0, 0, 0, 0.22),
+        inset 0  0.5px 0.5px rgba(255, 255, 255, 0.35),
+        0 0.5px 0.5px rgba(0, 0, 0, 0.12);
+}
+
+/* Specular highlight — tiny top-left pearl. Real Big Sur dots have one
+   positioned slightly off-center toward upper-left, sized so it reads as
+   reflected light on a glossy sphere rather than a sticker decoration. */
+.pro-light::after {
+    content: '';
+    position: absolute;
+    top: 2px; left: 2.5px;
+    width: 2.5px; height: 2px;
+    border-radius: 50%;
+    background: radial-gradient(ellipse at 35% 35%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0) 75%);
+    pointer-events: none;
+}
+
+/* Radial-gradient fills give each dot a 3D sphere feel rather than a flat
+   disc. The bright stop sits at 30%/25% to match where the specular pearl
+   reads as "this surface is lit from upper-left". */
+.pro-light--close {
+    background: radial-gradient(circle at 30% 25%, #FF8278 0%, var(--tl-close-fill) 55%, #E04339 100%);
+    border-color: var(--tl-close-border);
+}
+.pro-light--min {
+    background: radial-gradient(circle at 30% 25%, #FFD167 0%, var(--tl-min-fill) 55%, #DEA31E 100%);
+    border-color: var(--tl-min-border);
+}
+.pro-light--max {
+    background: radial-gradient(circle at 30% 25%, #6CDE7F 0%, var(--tl-max-fill) 55%, #18AB29 100%);
+    border-color: var(--tl-max-border);
+}
+
+/* Inactive (unfocused) windows: flat gray spheres, no colored radial,
+   no specular pearl. The cluster fades to ~60% opacity to match real
+   macOS behavior — colored dots only appear on the focused window. */
+.pro-window:not(.is-front) .pro-light {
+    background: radial-gradient(circle at 30% 25%, #E8E7E7 0%, var(--tl-inactive-fill) 60%, #C4C3C3 100%);
+    border-color: var(--tl-inactive-border);
+}
+.pro-window:not(.is-front) .pro-window__lights { opacity: 0.82; }
+.pro-window:not(.is-front) .pro-light::before { opacity: 0 !important; }
+.pro-window:not(.is-front) .pro-light::after  { opacity: 0; }
+/* Real macOS: hovering an inactive window's lights restores the color +
+   reveals the close/min/max glyphs, signalling "click to interact". */
+.pro-window:not(.is-front) .pro-window__lights:hover .pro-light::after { opacity: 0.7; }
+.pro-window:not(.is-front) .pro-window__lights:hover .pro-light--close {
+    background: radial-gradient(circle at 30% 25%, #FF8278 0%, var(--tl-close-fill) 55%, #E04339 100%);
+    border-color: var(--tl-close-border);
+}
+.pro-window:not(.is-front) .pro-window__lights:hover .pro-light--min {
+    background: radial-gradient(circle at 30% 25%, #FFD167 0%, var(--tl-min-fill) 55%, #DEA31E 100%);
+    border-color: var(--tl-min-border);
+}
+.pro-window:not(.is-front) .pro-window__lights:hover .pro-light--max {
+    background: radial-gradient(circle at 30% 25%, #6CDE7F 0%, var(--tl-max-fill) 55%, #18AB29 100%);
+    border-color: var(--tl-max-border);
+}
+.pro-window:not(.is-front) .pro-window__lights:hover .pro-light::before { opacity: 1 !important; }
+
+/* Hover any light → reveal glyphs on ALL three */
+.pro-light::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--tl-glyph);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+.pro-light--close::before { content: '×'; font-size: 12px; }
+.pro-light--min::before   { content: '–'; font-size: 13px; font-weight: 900; }
+.pro-light--max::before   { content: '+'; font-size: 11px; font-weight: 700; }
+
+.pro-window__lights:hover .pro-light::before { opacity: 1; }
+.pro-light:active { filter: brightness(0.9); }
+
+.pro-window__title {
+    flex: 1;
+    text-align: center;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--label);
+    letter-spacing: -0.005em;
+    margin: 0;
+    /* Mirror the lights cluster (12*3 + 8*2 = 52px + 12px padding) for visual centering */
+    padding-right: 64px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    pointer-events: none;
+}
+
+.pro-window__body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 22px 28px 26px;
+    background: rgba(255, 255, 255, 0.32);
+    scrollbar-width: thin;
+    scrollbar-color: var(--system-gray-3) transparent;
+}
+.pro-window__body::-webkit-scrollbar { width: 8px; }
+.pro-window__body::-webkit-scrollbar-thumb { background: var(--system-gray-3); border-radius: 4px; }
+.pro-window__body::-webkit-scrollbar-track { background: transparent; }
+
+/* Per-window sizes */
+.pro-window[data-app="about"]    { width: clamp(360px, 50vw, 560px); }
+.pro-window[data-app="work"]     { width: clamp(380px, 62vw, 740px); }
+.pro-window[data-app="research"] { width: clamp(380px, 55vw, 660px); }
+.pro-window[data-app="markets"]  { width: clamp(380px, 58vw, 700px); }
+.pro-window[data-app="terminal"] { width: clamp(380px, 56vw, 680px); }
+.pro-window[data-app="connect"]  { width: clamp(360px, 46vw, 520px); }
+
+/* ============================================================
+   WINDOW CONTENT TYPOGRAPHY
+   ============================================================ */
+.pro-h1 {
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: clamp(26px, 3vw, 36px);
+    line-height: 1.06;
+    letter-spacing: -0.025em;
+    margin: 0 0 6px;
+    color: var(--label);
+    font-variation-settings: 'opsz' 144;
+}
+.pro-h1 em { font-style: italic; color: var(--system-blue); }
+
+.pro-h2 {
+    font-family: var(--font-ui);
+    font-weight: 700;
+    font-size: clamp(20px, 2vw, 24px);
+    line-height: 1.2;
+    letter-spacing: -0.018em;
+    margin: 0 0 8px;
+}
+
+.pro-h-eyebrow {
+    font-family: var(--font-ui);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--system-blue);
+    margin: 0 0 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.pro-h-eyebrow::before {
+    content: '';
+    width: 20px; height: 1.5px;
+    background: var(--system-blue);
+    border-radius: 1px;
+}
+
+.pro-lede {
+    font-family: var(--font-ui);
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--label-2);
+    margin: 0 0 22px;
+    max-width: 60ch;
+    font-weight: 400;
+}
+
+.pro-rule {
+    border: 0;
+    border-top: 0.5px solid var(--separator);
+    margin: 22px 0;
+}
+
+/* About */
+.pro-about__bio p {
+    margin: 0 0 12px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--label);
+}
+.pro-about__bio p:last-child { margin-bottom: 0; }
+.pro-about__bio strong { font-weight: 600; }
+.pro-about__bio em { font-style: italic; color: var(--label); }
+
+.pro-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 18px;
+    list-style: none;
+    padding: 0;
+}
+.pro-tags li {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--label);
+    padding: 4px 10px;
+    border-radius: 99px;
+    background: var(--system-blue-soft);
+    color: var(--system-blue);
+}
+
+/* Work list */
+.pro-works { list-style: none; padding: 0; margin: 0; }
+.pro-work {
+    display: grid;
+    grid-template-columns: 36px 1fr auto;
+    gap: 14px 18px;
+    padding: 18px 0;
+    border-top: 0.5px solid var(--separator);
+    align-items: baseline;
+    transition: padding-left 0.45s var(--ease-soft), background 0.3s ease;
+    cursor: default;
+    border-radius: 6px;
+    margin: 0 -8px;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+.pro-work:first-child { border-top: 0; padding-top: 4px; }
+.pro-work:hover {
+    background: rgba(0, 122, 255, 0.05);
+    padding-left: 14px;
+}
+
+.pro-work__index {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 22px;
+    font-weight: 400;
+    color: var(--label-2);
+    line-height: 1;
+    font-variation-settings: 'opsz' 144;
+    transition: color 0.4s ease;
+}
+.pro-work:hover .pro-work__index { color: var(--system-blue); }
+
+.pro-work__title {
+    font-family: var(--font-ui);
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    margin: 0 0 5px;
+    line-height: 1.25;
+    color: var(--label);
+}
+.pro-work__desc {
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--label-2);
+    margin: 0 0 10px;
+    max-width: 56ch;
+}
+.pro-work__stack {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.pro-work__stack li {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--label-2);
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: rgba(60, 60, 67, 0.08);
+}
+
+.pro-work__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+    text-align: right;
+}
+.pro-work__meta time {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.02em;
+    color: var(--label-2);
+    font-feature-settings: 'tnum';
+}
+.pro-pill {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 3px 8px;
+    border-radius: 99px;
+    color: #fff;
+    background: var(--system-blue);
+    text-transform: uppercase;
+}
+.pro-pill[data-tone="research"]   { background: transparent; color: var(--system-blue); border: 1px solid var(--system-blue); }
+.pro-pill[data-tone="whitepaper"] { background: var(--system-purple); color: #fff; }
+.pro-pill[data-tone="internal"]   { background: var(--system-indigo); color: #fff; }
+
+/* Papers */
+.pro-papers { list-style: none; padding: 0; margin: 0; }
+.pro-paper {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: 16px;
+    padding: 16px 0;
+    border-top: 0.5px solid var(--separator);
+}
+.pro-paper:first-child { border-top: 0; padding-top: 0; }
+.pro-paper__year {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    letter-spacing: 0.02em;
+    color: var(--system-blue);
+    font-feature-settings: 'tnum';
+    font-weight: 600;
+}
+.pro-paper__title {
+    font-family: var(--font-ui);
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 5px;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    color: var(--label);
+}
+.pro-paper__authors {
+    font-size: 12.5px;
+    color: var(--label-2);
+    margin: 0;
+}
+.pro-paper__authors em { font-style: italic; color: var(--label); }
+.pro-paper__sep { color: var(--system-blue); margin: 0 6px; }
+
+/* Markets window */
+.pro-markets-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+    margin: 0 0 22px;
+}
+.pro-market-card {
+    border-radius: 10px;
+    padding: 12px 14px;
+    background: rgba(255, 255, 255, 0.55);
+    box-shadow: inset 0 0 0 0.5px var(--separator);
+}
+.pro-market-card__sym {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--label-2);
+    margin: 0 0 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.pro-market-card__val {
+    font-family: var(--font-mono);
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--label);
+    font-feature-settings: 'tnum';
+    letter-spacing: -0.02em;
+    margin: 0 0 3px;
+    line-height: 1;
+}
+.pro-market-card__delta {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    font-feature-settings: 'tnum';
+}
+.pro-market-card__delta.pro-up   { color: var(--system-green); }
+.pro-market-card__delta.pro-down { color: var(--system-red); }
+
+.pro-strat {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.5);
+    box-shadow: inset 0 0 0 0.5px var(--separator);
+    margin-bottom: 8px;
+    transition: background 0.3s ease, transform 0.35s var(--ease-spring);
+}
+.pro-strat:hover { background: rgba(0, 122, 255, 0.06); transform: translateX(3px); }
+.pro-strat__name { flex: 1; font-weight: 600; font-size: 13px; color: var(--label); }
+.pro-strat__sharpe {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--label-2);
+    letter-spacing: 0.02em;
+}
+.pro-strat__perf {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    font-feature-settings: 'tnum';
+}
+.pro-strat__perf.pro-up   { color: var(--system-green); }
+.pro-strat__perf.pro-down { color: var(--system-red); }
+
+/* Terminal — dark chrome variant. Specificity bumped via attribute selector
+   so the generic .pro-window:not(.is-front) chrome rule doesn't override it. */
+.pro-window[data-app="terminal"] .pro-window__chrome,
+.pro-window[data-app="terminal"]:not(.is-front) .pro-window__chrome {
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0) 60%),
+        rgba(40, 40, 44, 0.82);
+    border-bottom: 0.5px solid rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 0.5px 0 rgba(255, 255, 255, 0.10);
+}
+.pro-window[data-app="terminal"] .pro-window__title,
+.pro-window[data-app="terminal"]:not(.is-front) .pro-window__title {
+    color: rgba(255, 255, 255, 0.85);
+}
+.pro-window[data-app="terminal"]:not(.is-front) .pro-window__title { color: rgba(255, 255, 255, 0.55); }
+.pro-window[data-app="terminal"] .pro-window__body {
+    background: #1A1A1F;
+    padding: 16px 22px 22px;
+    color: rgba(255, 255, 255, 0.86);
+    font-family: var(--font-mono);
+}
+
+.pro-term { font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; }
+.pro-term__line { white-space: pre-wrap; }
+.pro-term__line .ps1 { color: var(--system-green); }
+.pro-term__line .arg { color: var(--system-blue); }
+.pro-term__out { color: rgba(255, 255, 255, 0.7); }
+.pro-term__cursor {
+    display: inline-block;
+    width: 7px; height: 14px;
+    background: var(--system-green);
+    vertical-align: -2px;
+    animation: pro-blink 1s steps(2) infinite;
+}
+@keyframes pro-blink { 50% { opacity: 0; } }
+
+/* Connect */
+.pro-connect {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+.pro-connect__primary {
+    font-family: var(--font-display);
+    font-size: clamp(22px, 3vw, 30px);
+    font-style: italic;
+    font-weight: 400;
+    color: var(--label);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 12px;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-variation-settings: 'opsz' 144;
+    transition: color 0.3s ease;
+}
+.pro-connect__primary:hover { color: var(--system-blue); }
+.pro-connect__primary span:last-child {
+    transition: transform 0.4s var(--ease-spring);
+    display: inline-block;
+}
+.pro-connect__primary:hover span:last-child { transform: translateX(10px); }
+
+.pro-connect__links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+}
+.pro-connect__links a {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.45);
+    box-shadow: inset 0 0 0 0.5px var(--separator);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--label);
+    text-decoration: none;
+    transition: background 0.25s ease, transform 0.3s var(--ease-spring), color 0.25s ease;
+}
+.pro-connect__links a:hover {
+    background: var(--system-blue);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: inset 0 0 0 0.5px var(--system-blue), 0 6px 14px -4px rgba(0, 122, 255, 0.4);
+}
+.pro-connect__links a span:last-child {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--label-3);
+    transition: transform 0.35s var(--ease-spring), color 0.25s ease;
+}
+.pro-connect__links a:hover span:last-child {
+    transform: translateX(3px);
+    color: #fff;
+}
+
+/* ============================================================
+   DOCK — authentic macOS (PuruVJ double-inset hairline)
+   ============================================================ */
+.pro-dock-wrap {
+    position: fixed;
+    bottom: 0; left: 0; right: 0;
+    height: var(--dock-h);
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding: 0 16px 10px;
+    pointer-events: none;
+    z-index: 60;
+}
+
+.pro-dock {
+    pointer-events: auto;
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+    padding: 6px 8px;
+
+    background: var(--m-dock-bg);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+
+    border-radius: var(--dock-radius);
+    box-shadow:
+        inset 0 0 0 0.5px rgba(255, 255, 255, 0.7),
+        inset 0 0 0 1.5px rgba(0, 0, 0, 0.04),
+        0 8px 28px rgba(0, 0, 0, 0.22),
+        0 4px 10px rgba(0, 0, 0, 0.10);
+
+    animation: pro-dock-in 0.9s var(--ease-spring) 0.3s both;
+}
+
+@keyframes pro-dock-in {
+    from { transform: translateY(140%); opacity: 0; }
+    to   { transform: translateY(0); opacity: 1; }
+}
+
+.pro-dock__icon {
+    position: relative;
+    width: var(--dock-icon);
+    height: var(--dock-icon);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform-origin: center bottom;
+    will-change: transform;
+    padding: 0;
+}
+.pro-dock__icon:active { transform: scale(0.92) !important; }
+
+.pro-dock__sq {
+    width: 100%;
+    height: 100%;
+    border-radius: var(--dock-icon-radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.32),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.18),
+        0 4px 10px -3px rgba(0, 0, 0, 0.35),
+        0 2px 4px -1px rgba(0, 0, 0, 0.18);
+}
+.pro-dock__sq::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.22) 0%, transparent 55%);
+    pointer-events: none;
+}
+.pro-dock__sq svg {
+    width: 26px; height: 26px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    position: relative;
+    z-index: 1;
+}
+
+/* Apple-system gradient themes */
+.pro-dock__sq[data-theme="ink"]      { background: linear-gradient(160deg, #5A5A60 0%, #1C1C1F 100%); }
+.pro-dock__sq[data-theme="blue"]     { background: linear-gradient(160deg, #4FA3FF 0%, #0050D8 100%); }
+.pro-dock__sq[data-theme="indigo"]   { background: linear-gradient(160deg, #8482E7 0%, #3F3DAA 100%); }
+.pro-dock__sq[data-theme="green"]    { background: linear-gradient(160deg, #5BD97A 0%, #1F9B3F 100%); }
+.pro-dock__sq[data-theme="purple"]   { background: linear-gradient(160deg, #C77AE6 0%, #7C2DAF 100%); }
+.pro-dock__sq[data-theme="orange"]   { background: linear-gradient(160deg, #FFAE3B 0%, #E0681A 100%); }
+.pro-dock__sq[data-theme="pink"]     { background: linear-gradient(160deg, #FF5E8A 0%, #C71F4D 100%); }
+.pro-dock__sq[data-theme="charcoal"] { background: linear-gradient(160deg, #2E2E33 0%, #15151A 100%); }
+
+/* Active running-app indicator (dot below) */
+.pro-dock__indicator {
+    position: absolute;
+    bottom: -6px;
+    left: 50%;
+    transform: translateX(-50%) scale(0);
+    width: 4px; height: 4px;
+    background: var(--dock-indicator);
+    border-radius: 50%;
+    transition: transform 0.3s var(--ease-spring);
+}
+.pro-dock__icon[data-active="true"] .pro-dock__indicator { transform: translateX(-50%) scale(1); }
+
+/* Tooltip label — Sequoia dock tooltip is a small dark pill with a tiny
+   triangle notch pointing at the icon. Tight font, modest shadow. */
+.pro-dock__label {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%) translateY(3px) scale(0.94);
+    background: rgba(40, 40, 44, 0.94);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    color: #fff;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 9px;
+    border-radius: 5px;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: transform 0.22s var(--ease-spring), opacity 0.16s ease;
+    box-shadow:
+        0 0 0 0.5px rgba(255, 255, 255, 0.06),
+        0 4px 10px -2px rgba(0, 0, 0, 0.45);
+    letter-spacing: -0.003em;
+}
+.pro-dock__label::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: rgba(40, 40, 44, 0.94);
+}
+.pro-dock__icon:hover .pro-dock__label {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+}
+
+/* Dock separator */
+.pro-dock__sep {
+    width: 0.5px;
+    height: 32px;
+    background: rgba(0, 0, 0, 0.18);
+    margin: 0 4px;
+    align-self: center;
+    flex-shrink: 0;
+}
+
+/* ============================================================
+   CREATIVE-MODE TOGGLE (in OS taskbar — cyberpunk)
+   ============================================================ */
+.creative-mode-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(0, 255, 255, 0.08);
+    border: 1px solid #0ff;
+    color: #0ff;
+    font-family: 'Courier New', 'Consolas', monospace;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    padding: 4px 12px;
+    cursor: pointer;
+    text-transform: uppercase;
+    transition: background 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease, color 0.25s ease;
+    margin: 0 12px 0 0;
+    line-height: 1.4;
+    text-shadow: 0 0 6px rgba(0, 255, 255, 0.5);
+    overflow: hidden;
+    animation: cmt-halo 3s ease-in-out infinite;
+    box-shadow: 0 0 0 0 rgba(0, 255, 255, 0.6), inset 0 0 8px rgba(0, 255, 255, 0.12);
+}
+.creative-mode-toggle::before {
+    content: '';
+    position: absolute;
+    top: 0; bottom: 0;
+    left: -60%;
+    width: 50%;
+    background: linear-gradient(100deg, transparent 0%, rgba(0, 255, 255, 0.55) 50%, transparent 100%);
+    transform: skewX(-18deg);
+    animation: cmt-shimmer 4.5s ease-in-out infinite;
+    pointer-events: none;
+}
+.creative-mode-toggle > * { position: relative; z-index: 1; }
+@keyframes cmt-shimmer {
+    0%        { left: -60%; }
+    30%, 100% { left: 130%; }
+}
+@keyframes cmt-halo {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(0, 255, 255, 0.55), inset 0 0 8px rgba(0, 255, 255, 0.12); }
+    50%      { box-shadow: 0 0 0 8px rgba(0, 255, 255, 0),    inset 0 0 16px rgba(0, 255, 255, 0.22); }
+}
+.creative-mode-toggle:hover {
+    background: rgba(0, 255, 255, 0.22);
+    color: #fff;
+    box-shadow: 0 0 18px rgba(0, 255, 255, 0.55), inset 0 0 18px rgba(0, 255, 255, 0.2);
+    transform: translateY(-1px);
+    animation-play-state: paused;
+}
+.creative-mode-toggle:active { transform: translateY(0); }
+.creative-mode-toggle__icon {
+    font-size: 13px;
+    display: inline-block;
+    animation: cmt-spin 8s linear infinite;
+}
+@keyframes cmt-spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+
+/* ============================================================
+   MODE-SWAP TRANSITION
+   ============================================================ */
+html.mode-swap #professional-mode,
+html.mode-swap #desktop,
+html.mode-swap #taskbar,
+html.mode-swap #start-menu {
+    animation: pro-fade-swap 0.5s var(--ease-soft);
+}
+@keyframes pro-fade-swap {
+    from { opacity: 0; transform: scale(0.985); }
+    to   { opacity: 1; transform: scale(1); }
+}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 920px) {
+    .pro-desktop {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto auto;
+        align-content: start;
+        padding-top: 60px;
+        overflow-y: auto;
+    }
+    .pro-spotlight, .pro-widgets { align-self: start; }
+}
+
+@media (max-width: 640px) {
+    #professional-mode { font-size: 14px; }
+
+    .pro-menubar { padding: 0 10px; }
+    .pro-menubar__nav, .pro-menubar__ticker, .pro-menubar__status, .pro-menubar__app { display: none; }
+    .pro-menubar__brand { font-size: 13px; }
+    .pro-mode-toggle { font-size: 10.5px; padding: 4px 9px 4px 7px; }
+
+    .pro-desktop { padding: 18px 16px 14px; gap: 20px; }
+    .pro-spotlight__name { font-size: clamp(44px, 12vw, 64px); }
+    .pro-spotlight__role { font-size: 14px; }
+
+    .pro-window {
+        width: calc(100vw - 24px) !important;
+        max-width: calc(100vw - 24px) !important;
+        max-height: calc(100vh - var(--menubar-h) - var(--dock-h) - 16px);
+    }
+    .pro-window__body { padding: 18px 18px 22px; }
+    .pro-window__title { font-size: 12px; }
+
+    .pro-dock-wrap { padding: 0 10px 6px; }
+    .pro-dock { gap: 3px; padding: 5px 8px; border-radius: 18px; }
+    .pro-dock__icon { width: 44px; height: 44px; }
+    .pro-dock__sq svg { width: 22px; height: 22px; }
+    .pro-dock__sep { height: 26px; }
+
+    .pro-work { grid-template-columns: 28px 1fr; }
+    .pro-work__meta { grid-column: 1 / -1; flex-direction: row; align-items: center; justify-content: space-between; padding-left: 42px; }
+
+    .creative-mode-toggle__label { display: none; }
+    .creative-mode-toggle { font-size: 10px; padding: 3px 9px; margin-right: 8px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #professional-mode *,
+    #professional-mode *::before,
+    #professional-mode *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+    .pro-wallpaper__mesh, .creative-mode-toggle, .creative-mode-toggle__icon { animation: none !important; }
+}

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -2,15 +2,11 @@
 
 /* Performance optimizations for mobile */
 @media (max-width: 768px) {
-    /* Optimize performance */
-    * {
-        -webkit-transform: translateZ(0);
-        transform: translateZ(0);
-        -webkit-backface-visibility: hidden;
-        backface-visibility: hidden;
-    }
-
-    /* Enable hardware acceleration for smooth scrolling */
+    /* Enable hardware acceleration for smooth scrolling.
+       NOTE: Do NOT apply `transform: translateZ(0)` via the universal (`*`)
+       selector — it makes every element a containing block for any
+       descendant `position: fixed`, which breaks the taskbar, start menu,
+       FAB, and windows on mobile. */
     body {
         -webkit-overflow-scrolling: touch;
         overflow-scrolling: touch;

--- a/assets/js/mobile.js
+++ b/assets/js/mobile.js
@@ -276,26 +276,19 @@ class MobileOptimizer {
     }
 
     optimizeWindowsForMobile() {
-        // Override window positioning for mobile
-        const originalOpenWindow = window.windowManager?.openWindow;
-        if (originalOpenWindow) {
-            window.windowManager.openWindow = function(windowId) {
-                const result = originalOpenWindow.call(this, windowId);
-                
-                if (window.innerWidth <= 768) {
-                    const windowElement = document.getElementById(windowId + '-window');
-                    if (windowElement) {
-                        windowElement.style.left = '5%';
-                        windowElement.style.top = '5%';
-                        windowElement.style.width = '90%';
-                        windowElement.style.height = '85%';
-                        windowElement.style.maxWidth = 'none';
-                        windowElement.style.maxHeight = 'none';
-                    }
-                }
-                
-                return result;
-            };
+        // Clear any leftover inline sizing on the elements at boot so the
+        // mobile CSS (`mobile-enhanced.css` `.window` rules) governs layout.
+        // The inline `style="left/top/width/height"` attributes from
+        // `index.html` are only meaningful on desktop.
+        if (window.innerWidth <= 768) {
+            document.querySelectorAll('.window').forEach(el => {
+                el.style.removeProperty('left');
+                el.style.removeProperty('top');
+                el.style.removeProperty('width');
+                el.style.removeProperty('height');
+                el.style.removeProperty('max-width');
+                el.style.removeProperty('max-height');
+            });
         }
     }
 
@@ -316,13 +309,9 @@ class MobileOptimizer {
     }
 
     addMobileMetaTags() {
-        // Prevent viewport zoom
-        let viewport = document.querySelector('meta[name="viewport"]');
-        if (viewport) {
-            viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
-        }
-        
-        // Add mobile web app capabilities
+        // Add mobile web app capabilities. The viewport meta is set in
+        // index.html — don't overwrite it here, which would re-disable
+        // pinch-zoom and hurt accessibility.
         this.addMetaTag('mobile-web-app-capable', 'yes');
         this.addMetaTag('apple-mobile-web-app-capable', 'yes');
         this.addMetaTag('apple-mobile-web-app-status-bar-style', 'black-translucent');

--- a/assets/js/mode-toggle.js
+++ b/assets/js/mode-toggle.js
@@ -1,0 +1,82 @@
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'twahirwa-mode';
+    var MODES = ['creative', 'professional'];
+    var html = document.documentElement;
+
+    function readMode() {
+        try {
+            var stored = localStorage.getItem(STORAGE_KEY);
+            return MODES.indexOf(stored) !== -1 ? stored : 'creative';
+        } catch (e) {
+            return 'creative';
+        }
+    }
+
+    function writeMode(mode) {
+        try { localStorage.setItem(STORAGE_KEY, mode); } catch (e) {}
+    }
+
+    function applyMode(mode, opts) {
+        if (MODES.indexOf(mode) === -1) return;
+        html.setAttribute('data-mode', mode);
+
+        if (opts && opts.animate) {
+            html.classList.add('mode-swap');
+            setTimeout(function () { html.classList.remove('mode-swap'); }, 520);
+        }
+
+        // Sync toggle buttons' target
+        var toggles = document.querySelectorAll('[data-mode-toggle]');
+        for (var i = 0; i < toggles.length; i++) {
+            var next = mode === 'creative' ? 'professional' : 'creative';
+            toggles[i].setAttribute('data-target', next);
+            toggles[i].setAttribute('aria-pressed', mode === 'professional' ? 'true' : 'false');
+        }
+
+        // Scroll to top when entering professional mode
+        if (mode === 'professional') {
+            window.scrollTo(0, 0);
+        }
+    }
+
+    // Initial application — synchronous, before any rendering matters
+    applyMode(readMode(), { animate: false });
+
+    // Wire up after DOM is interactive
+    function wire() {
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest && e.target.closest('[data-mode-toggle]');
+            if (!btn) return;
+            e.preventDefault();
+            var target = btn.getAttribute('data-target') ||
+                         (html.getAttribute('data-mode') === 'creative' ? 'professional' : 'creative');
+            writeMode(target);
+            applyMode(target, { animate: true });
+        });
+
+        // Sync buttons once DOM is ready
+        applyMode(readMode(), { animate: false });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+
+    // Public hook
+    window.TwahirwaMode = {
+        get: function () { return html.getAttribute('data-mode') || 'creative'; },
+        set: function (mode) {
+            if (MODES.indexOf(mode) === -1) return;
+            writeMode(mode);
+            applyMode(mode, { animate: true });
+        },
+        toggle: function () {
+            var current = html.getAttribute('data-mode') || 'creative';
+            this.set(current === 'creative' ? 'professional' : 'creative');
+        }
+    };
+})();

--- a/assets/js/professional.js
+++ b/assets/js/professional.js
@@ -1,0 +1,348 @@
+/* ============================================================
+   PROFESSIONAL MODE — OS behaviors
+   - Live clock & market ticker
+   - Dock magnification (cursor-distance scaling)
+   - Window manager (open / close / focus / drag)
+   - Spring-easy keyboard shortcut (Esc closes top window)
+   ============================================================ */
+(function () {
+    'use strict';
+
+    const root  = document.getElementById('professional-mode');
+    if (!root) return;
+
+    const html = document.documentElement;
+
+    // -------- Helpers --------
+    function $(sel, ctx) { return (ctx || root).querySelector(sel); }
+    function $$(sel, ctx) { return Array.prototype.slice.call((ctx || root).querySelectorAll(sel)); }
+
+    function isProMode() { return html.getAttribute('data-mode') === 'professional'; }
+
+    // ============================================================
+    // LIVE CLOCK + MARKET TICKER
+    // ============================================================
+    const clockEl  = $('#pro-clock');
+    const dateEl   = $('#pro-date');
+    const tickerEl = $('#pro-ticker-val');
+
+    const days   = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+    const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+    function fmt2(n) { return n < 10 ? '0' + n : '' + n; }
+
+    function tickClock() {
+        if (!clockEl) return;
+        const d  = new Date();
+        const hh = d.getHours();
+        const mm = fmt2(d.getMinutes());
+        const ap = hh >= 12 ? 'PM' : 'AM';
+        const h12 = ((hh + 11) % 12) + 1;
+        clockEl.textContent = days[d.getDay()] + ' ' + h12 + ':' + mm + ' ' + ap;
+        if (dateEl) dateEl.textContent = months[d.getMonth()] + ' ' + d.getDate();
+    }
+    setInterval(tickClock, 30000);
+    tickClock();
+
+    // Subtle ticker drift — micro-animates between two close values
+    let tickerBase = 0.42, tickerDir = 1;
+    function tickTicker() {
+        if (!tickerEl) return;
+        tickerBase += (Math.random() - 0.45) * 0.06 * tickerDir;
+        if (tickerBase > 0.85) tickerDir = -1;
+        if (tickerBase < 0.04) tickerDir =  1;
+        const sign = tickerBase >= 0 ? '+' : '';
+        tickerEl.textContent = sign + tickerBase.toFixed(2) + '%';
+        tickerEl.classList.toggle('pro-up',   tickerBase >= 0);
+        tickerEl.classList.toggle('pro-down', tickerBase <  0);
+    }
+    setInterval(tickTicker, 2400);
+
+    // Live mini-charts in Markets widget (random walk on the existing sparkline)
+    function animateSpark(svg) {
+        const pts = 36;
+        const w = 100, h = 36;
+        let y = 18 + (Math.random() - 0.5) * 6;
+        const points = [];
+        for (let i = 0; i < pts; i++) {
+            y += (Math.random() - 0.5) * 4;
+            y = Math.max(4, Math.min(h - 4, y));
+            points.push((i / (pts - 1) * w).toFixed(1) + ',' + y.toFixed(1));
+        }
+        const line = svg.querySelector('.pro-spark__line');
+        const fill = svg.querySelector('.pro-spark__fill');
+        if (line) line.setAttribute('points', points.join(' '));
+        if (fill) fill.setAttribute('points', '0,' + h + ' ' + points.join(' ') + ' ' + w + ',' + h);
+    }
+    $$('.pro-spark').forEach(animateSpark);
+    setInterval(function () {
+        if (!isProMode()) return;
+        $$('.pro-spark').forEach(animateSpark);
+    }, 4200);
+
+    // ============================================================
+    // WINDOW MANAGER
+    // ============================================================
+    let zCounter = 30;
+    const openSet = new Set();
+
+    function bringToFront(win) {
+        zCounter += 1;
+        win.style.zIndex = zCounter;
+        $$('.pro-window').forEach(function (w) { w.classList.toggle('is-front', w === win); });
+    }
+
+    function syncDockActive() {
+        $$('.pro-dock__icon').forEach(function (btn) {
+            const app = btn.getAttribute('data-open');
+            btn.setAttribute('data-active', openSet.has(app) ? 'true' : 'false');
+        });
+    }
+
+    function openWindow(app) {
+        const win = $('.pro-window[data-app="' + app + '"]');
+        if (!win) return;
+        // First-time positioning: slight cascade so opens stack nicely
+        if (!win.dataset.positioned) {
+            const offset = (openSet.size % 5) * 28;
+            win.style.marginLeft = offset + 'px';
+            win.style.marginTop  = offset + 'px';
+            win.dataset.positioned = '1';
+        }
+        win.classList.add('is-open');
+        openSet.add(app);
+        bringToFront(win);
+        syncDockActive();
+    }
+
+    function closeWindow(app) {
+        const win = $('.pro-window[data-app="' + app + '"]');
+        if (!win) return;
+        win.classList.remove('is-open');
+        openSet.delete(app);
+        syncDockActive();
+    }
+
+    function toggleWindow(app) {
+        if (openSet.has(app)) {
+            const win = $('.pro-window[data-app="' + app + '"]');
+            const front = $('.pro-window.is-front');
+            if (win === front) closeWindow(app); else bringToFront(win);
+        } else {
+            openWindow(app);
+        }
+    }
+
+    // Dock click handlers
+    $$('.pro-dock__icon').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const app = btn.getAttribute('data-open');
+            if (app) toggleWindow(app);
+        });
+    });
+
+    // Window control handlers (traffic lights)
+    $$('.pro-window').forEach(function (win) {
+        const app = win.getAttribute('data-app');
+
+        // Close
+        const closeBtn = $('.pro-light--close', win);
+        if (closeBtn) closeBtn.addEventListener('click', function (e) { e.stopPropagation(); closeWindow(app); });
+
+        // Minimize (acts like close — same affordance, no real minimize tray)
+        const minBtn = $('.pro-light--min', win);
+        if (minBtn) minBtn.addEventListener('click', function (e) { e.stopPropagation(); closeWindow(app); });
+
+        // Maximize → toggle expanded state
+        const maxBtn = $('.pro-light--max', win);
+        if (maxBtn) maxBtn.addEventListener('click', function (e) {
+            e.stopPropagation();
+            win.classList.toggle('is-max');
+        });
+
+        // Focus on click
+        win.addEventListener('mousedown', function () { bringToFront(win); });
+
+        // Drag by chrome
+        const chrome = $('.pro-window__chrome', win);
+        if (chrome) makeDraggable(win, chrome);
+    });
+
+    // Esc closes the top window
+    document.addEventListener('keydown', function (e) {
+        if (!isProMode()) return;
+        if (e.key !== 'Escape') return;
+        const front = $('.pro-window.is-front.is-open');
+        if (front) {
+            e.preventDefault();
+            closeWindow(front.getAttribute('data-app'));
+        }
+    });
+
+    function makeDraggable(win, handle) {
+        let startX, startY, baseX, baseY, dragging = false;
+        handle.addEventListener('mousedown', function (e) {
+            // Ignore traffic-light clicks
+            if (e.target.closest('.pro-light')) return;
+            dragging = true;
+            startX = e.clientX; startY = e.clientY;
+            const rect = win.getBoundingClientRect();
+            // Switch from translate-based centering to absolute positioning on first drag
+            if (!win.dataset.dragMode) {
+                win.style.left = rect.left + 'px';
+                win.style.top  = rect.top  + 'px';
+                win.style.transform = 'scale(1)';
+                win.style.margin = '0';
+                win.dataset.dragMode = '1';
+            }
+            baseX = parseFloat(win.style.left);
+            baseY = parseFloat(win.style.top);
+            handle.style.cursor = 'grabbing';
+            e.preventDefault();
+        });
+        window.addEventListener('mousemove', function (e) {
+            if (!dragging) return;
+            win.style.left = (baseX + (e.clientX - startX)) + 'px';
+            win.style.top  = (baseY + (e.clientY - startY)) + 'px';
+        });
+        window.addEventListener('mouseup', function () {
+            if (!dragging) return;
+            dragging = false;
+            handle.style.cursor = '';
+        });
+    }
+
+    // ============================================================
+    // DOCK MAGNIFICATION — cosine falloff (Renovamen-style)
+    // The 7-stop interpolation: distance → scale is non-linear,
+    // with the cursor's icon at max and neighbors interpolating.
+    // ============================================================
+    const dock = $('.pro-dock');
+    if (dock) {
+        const icons = $$('.pro-dock__icon', dock);
+        const MAX_SCALE = 1.55;
+        const LIFT = 22;          // px upward at peak
+        const RANGE = 130;        // influence radius (px) on each side
+        let raf = null, lastX = null;
+
+        // Cosine falloff: smooth, mac-like rolloff vs linear/quadratic
+        function curve(t) {
+            // t in [0, 1] where 1 = directly under cursor
+            // Cosine ease: peaks at 1, falls gently to 0
+            return (Math.cos((1 - t) * Math.PI) + 1) / 2;
+        }
+
+        function apply(x) {
+            icons.forEach(function (icon) {
+                const r = icon.getBoundingClientRect();
+                const cx = r.left + r.width / 2;
+                const d = Math.abs(x - cx);
+                if (d > RANGE) {
+                    icon.style.transform = '';
+                    return;
+                }
+                const t = 1 - d / RANGE;
+                const w = curve(t);
+                const scale = 1 + (MAX_SCALE - 1) * w;
+                const lift  = LIFT * w;
+                icon.style.transform = 'translateY(-' + lift.toFixed(1) + 'px) scale(' + scale.toFixed(3) + ')';
+            });
+        }
+
+        dock.addEventListener('mousemove', function (e) {
+            lastX = e.clientX;
+            if (raf) return;
+            raf = requestAnimationFrame(function () {
+                apply(lastX);
+                raf = null;
+            });
+        });
+
+        dock.addEventListener('mouseleave', function () {
+            icons.forEach(function (icon) { icon.style.transform = ''; });
+        });
+    }
+
+    // ============================================================
+    // SPOTLIGHT HINT — clicking it bounces the dock briefly
+    // ============================================================
+    const hint = $('.pro-spotlight__hint');
+    if (hint && dock) {
+        hint.style.cursor = 'pointer';
+        hint.addEventListener('click', function () {
+            dock.animate(
+                [{ transform: 'translateY(0)' }, { transform: 'translateY(-12px)' }, { transform: 'translateY(0)' }],
+                { duration: 600, easing: 'cubic-bezier(.34, 1.56, .64, 1)' }
+            );
+        });
+    }
+
+    // ============================================================
+    // RESET WINDOW POSITIONS WHEN ENTERING PRO MODE
+    // ============================================================
+    function resetWindowsOnEnter() {
+        if (!isProMode()) return;
+        $$('.pro-window').forEach(function (w) {
+            // Don't touch open windows, only the chrome state on reentry
+            if (!w.classList.contains('is-open')) {
+                w.style.removeProperty('left');
+                w.style.removeProperty('top');
+                w.style.removeProperty('margin');
+                w.style.removeProperty('transform');
+                delete w.dataset.dragMode;
+                delete w.dataset.positioned;
+            }
+        });
+    }
+    // Observe attribute changes on <html> to reset when entering pro mode
+    const obs = new MutationObserver(function (muts) {
+        muts.forEach(function (m) {
+            if (m.attributeName === 'data-mode') {
+                resetWindowsOnEnter();
+                maybeAutoOpenAbout();
+            }
+        });
+    });
+    obs.observe(html, { attributes: true });
+
+    // ============================================================
+    // FIRST-LAUNCH AUTO-OPEN
+    // On a visitor's first time entering professional mode, open the
+    // About window automatically so they immediately see a real macOS
+    // window — traffic lights, vibrancy, chrome, the whole language.
+    // After that, respect the user's choice and stay quiet.
+    //
+    // QA tip: in DevTools console, run
+    //   localStorage.removeItem('tt:pro:first-launch-done')
+    // then reload — the auto-open will re-trigger.
+    // ============================================================
+    const FIRST_LAUNCH_KEY = 'tt:pro:first-launch-done';
+
+    function hasSeenFirstLaunch() {
+        try { return localStorage.getItem(FIRST_LAUNCH_KEY) === '1'; }
+        catch (e) { return false; }
+    }
+    function markFirstLaunchSeen() {
+        try { localStorage.setItem(FIRST_LAUNCH_KEY, '1'); } catch (e) { /* private mode, fine */ }
+    }
+
+    let autoOpenScheduled = false;
+    function maybeAutoOpenAbout() {
+        if (!isProMode()) return;
+        if (hasSeenFirstLaunch()) return;
+        if (autoOpenScheduled) return;
+        autoOpenScheduled = true;
+        // 720ms lets the dock spring (0.3s delay + 0.9s travel) settle just
+        // before About opens — feels like the OS finishing its launch sequence.
+        setTimeout(function () {
+            if (!isProMode()) { autoOpenScheduled = false; return; }
+            if (hasSeenFirstLaunch()) return;
+            openWindow('about');
+            markFirstLaunchSeen();
+        }, 720);
+    }
+
+    // Run once on initial load (covers the case where the page boots straight into pro mode)
+    maybeAutoOpenAbout();
+
+})();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- Essential Meta Tags -->
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     
     <!-- iOS Safari Optimizations -->
@@ -55,6 +55,11 @@
     <link rel="preload" href="/assets/css/main.css" as="style">
     <link rel="preload" href="/assets/js/init.js" as="script">
 
+    <!-- Fonts (Professional Mode) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..600&family=Inter+Tight:wght@300..700&family=JetBrains+Mono:wght@400;500&display=swap">
+
     <!-- CSS Files -->
     <link rel="stylesheet" href="assets/css/main.css">
     <link rel="stylesheet" href="assets/css/windows.css">
@@ -62,6 +67,20 @@
     <link rel="stylesheet" href="assets/css/responsive.css">
     <link rel="stylesheet" href="assets/css/mobile.css">
     <link rel="stylesheet" href="assets/css/mobile-enhanced.css">
+    <link rel="stylesheet" href="assets/css/professional.css">
+
+    <!-- Mode bootstrap (set as early as possible to prevent FOUC) -->
+    <script>
+        (function () {
+            try {
+                var m = localStorage.getItem('twahirwa-mode');
+                if (m !== 'professional' && m !== 'creative') m = 'creative';
+                document.documentElement.setAttribute('data-mode', m);
+            } catch (e) {
+                document.documentElement.setAttribute('data-mode', 'creative');
+            }
+        })();
+    </script>
 
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">
@@ -442,9 +461,473 @@
         <button class="start-button" id="start-button">START</button>
         <div class="taskbar-items" id="taskbar-items"></div>
         <div class="system-tray">
+            <button class="creative-mode-toggle" data-mode-toggle data-target="professional" aria-label="Switch to professional portfolio mode">
+                <span class="creative-mode-toggle__icon" aria-hidden="true">◐</span>
+                <span class="creative-mode-toggle__label">PRO_MODE</span>
+            </button>
             <span id="clock">00:00</span>
             <span>|</span>
             <span>MODE: <span style="color: #0f0;">CREATIVE</span></span>
+        </div>
+    </div>
+
+    <!-- ============================================================
+         PROFESSIONAL MODE — macOS-style desktop OS
+         Quant / Data / AI Portfolio · TJT.app
+         ============================================================ -->
+    <div id="professional-mode">
+        <!-- Wallpaper -->
+        <div class="pro-wallpaper" aria-hidden="true">
+            <div class="pro-wallpaper__mesh"></div>
+            <div class="pro-wallpaper__grain"></div>
+        </div>
+
+        <!-- Menu bar -->
+        <header class="pro-menubar">
+            <div class="pro-menubar__left">
+                <button class="pro-menubar__brand" type="button">
+                    <span class="pro-brand-mark" aria-hidden="true"></span>
+                    <span>Twahirwa</span>
+                </button>
+                <span class="pro-menubar__app">Quant.app</span>
+                <nav class="pro-menubar__nav" aria-label="App menu">
+                    <button type="button">File</button>
+                    <button type="button">View</button>
+                    <button type="button">Window</button>
+                    <button type="button">Help</button>
+                </nav>
+            </div>
+            <div class="pro-menubar__right">
+                <span class="pro-menubar__ticker" aria-label="SPX index">
+                    <span class="pro-ticker__label">SPX</span>
+                    <span class="pro-ticker__value pro-up" id="pro-ticker-val">+0.42%</span>
+                </span>
+                <span class="pro-menubar__status">
+                    <span class="pro-pulse-dot" aria-hidden="true"></span>
+                    Live
+                </span>
+                <time class="pro-menubar__clock" id="pro-clock">— —:— —</time>
+                <button class="pro-mode-toggle pro-mode-toggle--attention" data-mode-toggle data-target="creative" aria-label="Switch to creative OS mode">
+                    <span class="pro-mode-toggle__dot" aria-hidden="true"></span>
+                    <span>creative.os</span>
+                </button>
+            </div>
+        </header>
+
+        <!-- Desktop -->
+        <main class="pro-desktop">
+            <!-- Spotlight (always-visible hero on desktop) -->
+            <section class="pro-spotlight" aria-labelledby="pro-spot-title">
+                <p class="pro-spotlight__eyebrow">Portfolio · MMXXVI</p>
+                <h1 class="pro-spotlight__name" id="pro-spot-title">
+                    Thibault <em>J.</em><br>Twahirwa<span>.</span>
+                </h1>
+                <p class="pro-spotlight__role">
+                    Quantitative researcher · data scientist · music producer · quantum enthusiast.
+                    7+ years building systems at the intersection of capital markets, applied AI,
+                    and sustainable finance. Based in New York.
+                </p>
+                <p class="pro-spotlight__hint">
+                    Open an item below
+                    <span class="pro-arr-down" aria-hidden="true">↓</span>
+                </p>
+            </section>
+
+            <!-- Desktop widgets -->
+            <section class="pro-widgets" aria-label="Desktop widgets">
+                <article class="pro-widget pro-widget--ledger">
+                    <header class="pro-widget__head">
+                        <h2 class="pro-widget__title">At a glance</h2>
+                        <span class="pro-widget__caption">— ledger</span>
+                    </header>
+                    <dl>
+                        <div class="pro-row"><dt>Discipline</dt><dd>Quant · Data · ML · ESG</dd></div>
+                        <div class="pro-row"><dt>Tenure</dt><dd>7+ years</dd></div>
+                        <div class="pro-row"><dt>Stack</dt><dd>Python · JAX · kdb+ · CUDA</dd></div>
+                        <div class="pro-row"><dt>Education</dt><dd>Columbia · Notre Dame · Morehouse</dd></div>
+                        <div class="pro-row"><dt>Read</dt><dd>EN · FR · KIN</dd></div>
+                    </dl>
+                </article>
+
+                <article class="pro-widget pro-widget--markets">
+                    <header class="pro-widget__head">
+                        <h2 class="pro-widget__title">Markets</h2>
+                        <span class="pro-widget__caption">— live</span>
+                    </header>
+                    <div class="pro-markets">
+                        <div class="pro-market">
+                            <span class="pro-market__sym">SPX</span>
+                            <span class="pro-market__val">5,847.16</span>
+                            <span class="pro-market__delta pro-up">+0.42%</span>
+                        </div>
+                        <div class="pro-market">
+                            <span class="pro-market__sym">VIX</span>
+                            <span class="pro-market__val">14.28</span>
+                            <span class="pro-market__delta pro-down">−1.86%</span>
+                        </div>
+                    </div>
+                    <svg class="pro-spark" viewBox="0 0 100 36" preserveAspectRatio="none">
+                        <polygon class="pro-spark__fill" points="0,36 100,36"/>
+                        <polyline class="pro-spark__line" points="0,18 100,18"/>
+                    </svg>
+                </article>
+
+                <article class="pro-widget pro-widget--now">
+                    <div class="pro-now__art" aria-hidden="true"></div>
+                    <div class="pro-now__body">
+                        <p class="pro-now__label">Now Playing — DJ Mode</p>
+                        <p class="pro-now__title">Data Rhythms</p>
+                    </div>
+                    <div class="pro-now__bars" aria-hidden="true">
+                        <span></span><span></span><span></span><span></span><span></span>
+                    </div>
+                </article>
+            </section>
+        </main>
+
+        <!-- ============================================================
+             WINDOWS
+             ============================================================ -->
+
+        <!-- About -->
+        <article class="pro-window" data-app="about" role="dialog" aria-labelledby="win-about-title">
+            <header class="pro-window__chrome">
+                <div class="pro-window__lights" aria-label="Window controls">
+                    <button class="pro-light pro-light--close" type="button" aria-label="Close"></button>
+                    <button class="pro-light pro-light--min"   type="button" aria-label="Minimize"></button>
+                    <button class="pro-light pro-light--max"   type="button" aria-label="Maximize"></button>
+                </div>
+                <h2 class="pro-window__title" id="win-about-title">About — Thibault J. Twahirwa</h2>
+            </header>
+            <div class="pro-window__body">
+                <p class="pro-h-eyebrow">Profile</p>
+                <h1 class="pro-h1">Thibault <em>J.</em> Twahirwa</h1>
+                <p class="pro-lede">Data Scientist · Music Producer · Quantum Enthusiast — 7+ years building systems at the intersection of capital markets, applied AI, and sustainable finance.</p>
+                <div class="pro-about__bio">
+                    <p>Currently focused on <strong>ESG analytics</strong>, factor research, and applied AI for systematic strategies. Published researcher with prior work in quantum-dot heat transfer and field-emission micro-discharges.</p>
+                    <p>Multilingual technologist. Based in New York. Rwandan-American by background; Columbia · Notre Dame · Morehouse by training.</p>
+                </div>
+                <ul class="pro-tags" aria-label="Areas">
+                    <li>Quant Research</li>
+                    <li>Machine Learning</li>
+                    <li>ESG Analytics</li>
+                    <li>Sustainable Finance</li>
+                    <li>Music Production</li>
+                    <li>Quantum Physics</li>
+                </ul>
+            </div>
+        </article>
+
+        <!-- Work / Projects -->
+        <article class="pro-window" data-app="work" role="dialog" aria-labelledby="win-work-title">
+            <header class="pro-window__chrome">
+                <div class="pro-window__lights" aria-label="Window controls">
+                    <button class="pro-light pro-light--close" type="button" aria-label="Close"></button>
+                    <button class="pro-light pro-light--min"   type="button" aria-label="Minimize"></button>
+                    <button class="pro-light pro-light--max"   type="button" aria-label="Maximize"></button>
+                </div>
+                <h2 class="pro-window__title" id="win-work-title">Projects · Selected Work</h2>
+            </header>
+            <div class="pro-window__body">
+                <p class="pro-h-eyebrow">§ Portfolio</p>
+                <h2 class="pro-h2">Selected Work</h2>
+                <p class="pro-lede">Deployed systems and live research across quant, data, and applied AI.</p>
+
+                <ol class="pro-works">
+                    <li class="pro-work">
+                        <span class="pro-work__index" aria-hidden="true">01</span>
+                        <div>
+                            <h3 class="pro-work__title">Quantum Music Generator</h3>
+                            <p class="pro-work__desc">Converting quantum-particle behaviour into musical compositions — a bridge between physics, ML, and creative practice.</p>
+                            <ul class="pro-work__stack"><li>Python</li><li>Qiskit</li><li>MIDI</li><li>TensorFlow</li></ul>
+                        </div>
+                        <span class="pro-work__meta">
+                            <time>2023 — present</time>
+                            <span class="pro-pill" data-tone="research">research</span>
+                        </span>
+                    </li>
+                    <li class="pro-work">
+                        <span class="pro-work__index" aria-hidden="true">02</span>
+                        <div>
+                            <h3 class="pro-work__title">ESG Analytics Platform</h3>
+                            <p class="pro-work__desc">Open-source tools for sustainability data analysis and visualisation — built for analysts and quants needing reproducible ESG signal pipelines.</p>
+                            <ul class="pro-work__stack"><li>Python</li><li>Spark</li><li>D3.js</li><li>Cloud</li></ul>
+                        </div>
+                        <span class="pro-work__meta">
+                            <time>2022 — present</time>
+                            <span class="pro-pill">production</span>
+                        </span>
+                    </li>
+                    <li class="pro-work">
+                        <span class="pro-work__index" aria-hidden="true">03</span>
+                        <div>
+                            <h3 class="pro-work__title">Sonification-as-Inference</h3>
+                            <p class="pro-work__desc">Treating high-frequency market microstructure as audio. Self-supervised representations of order-book spectrograms surface anomalies that conventional surveillance misses.</p>
+                            <ul class="pro-work__stack"><li>torch</li><li>librosa</li><li>cuda</li></ul>
+                        </div>
+                        <span class="pro-work__meta">
+                            <time>2024 — present</time>
+                            <span class="pro-pill" data-tone="research">research</span>
+                        </span>
+                    </li>
+                    <li class="pro-work">
+                        <span class="pro-work__index" aria-hidden="true">04</span>
+                        <div>
+                            <h3 class="pro-work__title">Quantum-Inspired Portfolio Optimisation</h3>
+                            <p class="pro-work__desc">QAOA-style approaches to constrained mean-variance optimisation under realistic transaction-cost models. Internal whitepaper.</p>
+                            <ul class="pro-work__stack"><li>Qiskit</li><li>Gurobi</li><li>Python</li></ul>
+                        </div>
+                        <span class="pro-work__meta">
+                            <time>2022 — 2023</time>
+                            <span class="pro-pill" data-tone="whitepaper">whitepaper</span>
+                        </span>
+                    </li>
+                </ol>
+            </div>
+        </article>
+
+        <!-- Research -->
+        <article class="pro-window" data-app="research" role="dialog" aria-labelledby="win-research-title">
+            <header class="pro-window__chrome">
+                <div class="pro-window__lights" aria-label="Window controls">
+                    <button class="pro-light pro-light--close" type="button" aria-label="Close"></button>
+                    <button class="pro-light pro-light--min"   type="button" aria-label="Minimize"></button>
+                    <button class="pro-light pro-light--max"   type="button" aria-label="Maximize"></button>
+                </div>
+                <h2 class="pro-window__title" id="win-research-title">Research · Publications</h2>
+            </header>
+            <div class="pro-window__body">
+                <p class="pro-h-eyebrow">§ Research</p>
+                <h2 class="pro-h2">Published Research</h2>
+                <p class="pro-lede">Peer-reviewed work in nanoscience and field-emission physics, with current research extending into data sonification.</p>
+
+                <ul class="pro-papers">
+                    <li class="pro-paper">
+                        <span class="pro-paper__year">2014</span>
+                        <div>
+                            <h3 class="pro-paper__title">Quantum Dots &amp; Silver Nanoparticles</h3>
+                            <p class="pro-paper__authors">Enhanced heat transfer in quantum dots using synthesized silver nanoprism particles. <span class="pro-paper__sep">·</span> <em>Journal of Physical Chemistry</em></p>
+                        </div>
+                    </li>
+                    <li class="pro-paper">
+                        <span class="pro-paper__year">2014</span>
+                        <div>
+                            <h3 class="pro-paper__title">Electron Impact Ionization</h3>
+                            <p class="pro-paper__authors">Experimental study of field-emission-driven micro-discharges. <span class="pro-paper__sep">·</span> <em>Applied Physics</em></p>
+                        </div>
+                    </li>
+                    <li class="pro-paper">
+                        <span class="pro-paper__year">2026</span>
+                        <div>
+                            <h3 class="pro-paper__title">Data Sonification for Pattern Recognition</h3>
+                            <p class="pro-paper__authors">Converting complex datasets into audio signals for high-dimensional anomaly detection. <span class="pro-paper__sep">·</span> <em>In preparation</em></p>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </article>
+
+        <!-- Markets -->
+        <article class="pro-window" data-app="markets" role="dialog" aria-labelledby="win-markets-title">
+            <header class="pro-window__chrome">
+                <div class="pro-window__lights" aria-label="Window controls">
+                    <button class="pro-light pro-light--close" type="button" aria-label="Close"></button>
+                    <button class="pro-light pro-light--min"   type="button" aria-label="Minimize"></button>
+                    <button class="pro-light pro-light--max"   type="button" aria-label="Maximize"></button>
+                </div>
+                <h2 class="pro-window__title" id="win-markets-title">Markets · Live Snapshot</h2>
+            </header>
+            <div class="pro-window__body">
+                <p class="pro-h-eyebrow">§ Live</p>
+                <h2 class="pro-h2">Markets &amp; Strategies</h2>
+                <p class="pro-lede">A live demo dashboard — illustrative only, refreshed for motion.</p>
+
+                <div class="pro-markets-grid">
+                    <div class="pro-market-card">
+                        <p class="pro-market-card__sym">S&amp;P 500</p>
+                        <p class="pro-market-card__val">5,847.16</p>
+                        <p class="pro-market-card__delta pro-up">+24.6 · +0.42%</p>
+                    </div>
+                    <div class="pro-market-card">
+                        <p class="pro-market-card__sym">VIX</p>
+                        <p class="pro-market-card__val">14.28</p>
+                        <p class="pro-market-card__delta pro-down">−0.27 · −1.86%</p>
+                    </div>
+                    <div class="pro-market-card">
+                        <p class="pro-market-card__sym">US10Y</p>
+                        <p class="pro-market-card__val">4.184%</p>
+                        <p class="pro-market-card__delta pro-up">+0.03 bp</p>
+                    </div>
+                    <div class="pro-market-card">
+                        <p class="pro-market-card__sym">BTC</p>
+                        <p class="pro-market-card__val">$ 92,418</p>
+                        <p class="pro-market-card__delta pro-up">+2.14%</p>
+                    </div>
+                </div>
+
+                <p class="pro-h-eyebrow" style="margin-top: 4px;">Strategy Track</p>
+                <div class="pro-strat">
+                    <span class="pro-strat__name">ESG Alpha · Long-Only</span>
+                    <span class="pro-strat__sharpe">Sharpe 2.41</span>
+                    <span class="pro-strat__perf pro-up">+47.2% YTD</span>
+                </div>
+                <div class="pro-strat">
+                    <span class="pro-strat__name">Quant-Inspired MV Opt.</span>
+                    <span class="pro-strat__sharpe">Sharpe 1.87</span>
+                    <span class="pro-strat__perf pro-up">+22.4%</span>
+                </div>
+                <div class="pro-strat">
+                    <span class="pro-strat__name">Macro Causal Lens</span>
+                    <span class="pro-strat__sharpe">Sharpe 1.32</span>
+                    <span class="pro-strat__perf pro-down">−1.4%</span>
+                </div>
+            </div>
+        </article>
+
+        <!-- Terminal -->
+        <article class="pro-window" data-app="terminal" role="dialog" aria-labelledby="win-terminal-title">
+            <header class="pro-window__chrome">
+                <div class="pro-window__lights" aria-label="Window controls">
+                    <button class="pro-light pro-light--close" type="button" aria-label="Close"></button>
+                    <button class="pro-light pro-light--min"   type="button" aria-label="Minimize"></button>
+                    <button class="pro-light pro-light--max"   type="button" aria-label="Maximize"></button>
+                </div>
+                <h2 class="pro-window__title" id="win-terminal-title">Terminal — tjt@quant ~ %</h2>
+            </header>
+            <div class="pro-window__body">
+                <div class="pro-term">
+                    <div class="pro-term__line"><span class="ps1">tjt@quant ~ %</span> <span class="arg">whoami</span></div>
+                    <div class="pro-term__out">Thibault J. Twahirwa — data scientist · quant researcher · NYC</div>
+                    <div class="pro-term__line">&nbsp;</div>
+                    <div class="pro-term__line"><span class="ps1">tjt@quant ~ %</span> <span class="arg">cat ~/now.txt</span></div>
+                    <div class="pro-term__out">Building ESG factor libraries and sonification-based inference.</div>
+                    <div class="pro-term__out">Open to research collaborations in sustainable finance &amp; applied AI.</div>
+                    <div class="pro-term__line">&nbsp;</div>
+                    <div class="pro-term__line"><span class="ps1">tjt@quant ~ %</span> <span class="arg">uname -a</span></div>
+                    <div class="pro-term__out">TWAHIRWA-OS · v.II Quant Edition · arm64 · NYC · 40.7°N 74.0°W</div>
+                    <div class="pro-term__line">&nbsp;</div>
+                    <div class="pro-term__line"><span class="ps1">tjt@quant ~ %</span> <span class="pro-term__cursor" aria-hidden="true"></span></div>
+                </div>
+            </div>
+        </article>
+
+        <!-- Connect -->
+        <article class="pro-window" data-app="connect" role="dialog" aria-labelledby="win-connect-title">
+            <header class="pro-window__chrome">
+                <div class="pro-window__lights" aria-label="Window controls">
+                    <button class="pro-light pro-light--close" type="button" aria-label="Close"></button>
+                    <button class="pro-light pro-light--min"   type="button" aria-label="Minimize"></button>
+                    <button class="pro-light pro-light--max"   type="button" aria-label="Maximize"></button>
+                </div>
+                <h2 class="pro-window__title" id="win-connect-title">Connect</h2>
+            </header>
+            <div class="pro-window__body">
+                <p class="pro-h-eyebrow">Correspondence</p>
+                <h2 class="pro-h2">Direct lines</h2>
+                <p class="pro-lede">NYC · 🇷🇼🇺🇸 Rwandan-American. Open to research collaborations.</p>
+
+                <div class="pro-connect">
+                    <a class="pro-connect__primary" href="mailto:thibault.twahirwa@gmail.com">
+                        <span>thibault.twahirwa@gmail.com</span>
+                        <span aria-hidden="true">→</span>
+                    </a>
+                    <ul class="pro-connect__links">
+                        <li><a href="#" data-platform="linkedin"><span>LinkedIn</span><span>↗</span></a></li>
+                        <li><a href="#" data-platform="github"><span>GitHub</span><span>↗</span></a></li>
+                        <li><a href="#" data-platform="instagram"><span>Instagram</span><span>↗</span></a></li>
+                        <li><a href="#" data-platform="youtube"><span>YouTube</span><span>↗</span></a></li>
+                        <li><a href="#" data-platform="tiktok"><span>TikTok</span><span>↗</span></a></li>
+                        <li><a href="#" data-platform="scholar"><span>Scholar</span><span>↗</span></a></li>
+                    </ul>
+                </div>
+            </div>
+        </article>
+
+        <!-- ============================================================
+             DOCK
+             ============================================================ -->
+        <div class="pro-dock-wrap">
+            <div class="pro-dock" role="toolbar" aria-label="Application dock">
+                <button class="pro-dock__icon" data-open="about" type="button">
+                    <span class="pro-dock__sq" data-theme="ink">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <circle cx="12" cy="9" r="3.5"/>
+                            <path d="M5 19c1.4-3.4 4-5 7-5s5.6 1.6 7 5"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">About</span>
+                    <span class="pro-dock__indicator" aria-hidden="true"></span>
+                </button>
+
+                <button class="pro-dock__icon" data-open="work" type="button">
+                    <span class="pro-dock__sq" data-theme="blue">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M4 18v-7l4 3 4-6 4 4 4-6"/>
+                            <path d="M4 20h16"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">Projects</span>
+                    <span class="pro-dock__indicator" aria-hidden="true"></span>
+                </button>
+
+                <button class="pro-dock__icon" data-open="research" type="button">
+                    <span class="pro-dock__sq" data-theme="indigo">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M5 4h11l3 3v13H5z"/>
+                            <path d="M8 9h7M8 13h7M8 17h5"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">Research</span>
+                    <span class="pro-dock__indicator" aria-hidden="true"></span>
+                </button>
+
+                <button class="pro-dock__icon" data-open="markets" type="button">
+                    <span class="pro-dock__sq" data-theme="green">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M4 16l4-4 3 3 4-6 5 7"/>
+                            <path d="M4 20h16"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">Markets</span>
+                    <span class="pro-dock__indicator" aria-hidden="true"></span>
+                </button>
+
+                <span class="pro-dock__sep" aria-hidden="true"></span>
+
+                <button class="pro-dock__icon" data-open="terminal" type="button">
+                    <span class="pro-dock__sq" data-theme="charcoal">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M5 8l4 4-4 4"/>
+                            <path d="M12 17h7"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">Terminal</span>
+                    <span class="pro-dock__indicator" aria-hidden="true"></span>
+                </button>
+
+                <button class="pro-dock__icon" data-open="connect" type="button">
+                    <span class="pro-dock__sq" data-theme="orange">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <rect x="3.5" y="6" width="17" height="13" rx="2"/>
+                            <path d="M4 8l8 6 8-6"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">Connect</span>
+                    <span class="pro-dock__indicator" aria-hidden="true"></span>
+                </button>
+
+                <span class="pro-dock__sep" aria-hidden="true"></span>
+
+                <button class="pro-dock__icon pro-dock__icon--mode" data-mode-toggle data-target="creative" type="button" aria-label="Switch to creative OS mode">
+                    <span class="pro-dock__sq" data-theme="purple">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <circle cx="12" cy="12" r="7"/>
+                            <path d="M12 5v14M5 12h14"/>
+                        </svg>
+                    </span>
+                    <span class="pro-dock__label">Switch to Creative</span>
+                </button>
+            </div>
         </div>
     </div>
 
@@ -456,5 +939,7 @@
     <script src="assets/js/app.js"></script>
     <script src="assets/js/mobile.js"></script>
     <script src="assets/js/init.js"></script>
+    <script src="assets/js/mode-toggle.js"></script>
+    <script src="assets/js/professional.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Introduces a **dual-mode site** with a clean toggle between two distinct aesthetics:

- **Creative mode** — the existing cyberpunk Win95 OS (preserved unchanged)
- **Professional mode** — a new authentic macOS Sonoma/Sequoia-style desktop OS, oriented toward a quant / data / AI audience

The same content (about, projects, research, contact, terminal) lives in both — visitors switch between aesthetics via a persistent toggle.

## Professional mode highlights

- Translucent menu bar with brand mark, live clock, micro-animated market ticker, status indicator
- Sequoia-inspired "Graphite dusk" gradient wallpaper (cool navy/indigo/slate)
- Six glass windows (About, Projects, Research, Markets, Terminal, Connect) with authentic Big Sur+ traffic lights (3D-sphere rendering, hover-on-cluster glyph reveal, inactive-state graying)
- macOS dock with cosine-curve magnification, squircle icons in Apple-system color themes, dark tooltip pills
- Glass widgets (ledger, live markets sparkline, now-playing equalizer)
- Auto-opens About window on first visit (localStorage gated)
- Typography: Inter Tight + ` -apple-system` fallback so Apple users render real SF Pro; Fraunces for editorial display
- Spring motion on window open/close, dock lift, hero stagger

## Mode toggle

- Persistent state in localStorage, applied synchronously in `<head>` to prevent FOUC
- Two prominent toggle buttons (cyan pill in creative taskbar + Apple-blue pill in pro menu bar) with shimmer + halo attention animations
- Switcher also lives at the right end of the pro dock for discoverability

## Mobile fixes (bundled)

- Removes universal `* { transform: translateZ(0) }` that broke `position: fixed` on iOS
- Uses `100dvh` and accounts for the 50px mobile taskbar + safe-area-bottom in `#desktop` height
- Frees viewport zoom (removes `maximum-scale=1.0, user-scalable=no`)
- Lifts mobile FAB above taskbar with safe-area awareness
- Stops `mobile.js` from overwriting the viewport meta on init

## Test plan

- [ ] Load on desktop — site defaults to creative mode (existing behavior preserved)
- [ ] Click ◐ PRO_MODE in the taskbar — switches to professional mode, About window auto-opens
- [ ] Refresh in pro mode — state persists, About does NOT re-auto-open
- [ ] Click each dock icon — its window opens with proper traffic lights, draggable chrome
- [ ] Click red traffic light — closes window; yellow — closes; green — toggles maximize
- [ ] Hover any one traffic light — all three glyphs (× – +) reveal across the cluster
- [ ] Open multiple windows — they cascade and bring-to-front correctly on focus
- [ ] Press Esc — top window closes
- [ ] Switch back to creative mode via menu-bar pill or violet dock tile
- [ ] On mobile (≤768px wide) — site fits viewport, no overlap with taskbar, FAB clears taskbar
- [ ] Pinch-zoom is no longer blocked on mobile
- [ ] Clear `localStorage` key `tt:pro:first-launch-done` in DevTools — verify About auto-opens again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/twajothi/twahirwa.com/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->